### PR TITLE
Fixed http post json couldn't read body

### DIFF
--- a/csrfbanana_test.go
+++ b/csrfbanana_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"testing"
 
+	"encoding/json"
 	"github.com/gorilla/sessions"
 )
 
@@ -111,6 +112,16 @@ func TestCSRFJSON(t *testing.T) {
 	if w.Code != 200 {
 		t.Errorf("The request should have succeeded, but it didn't. Instead, the code was %d",
 			w.Code)
+	}
+
+	p := struct {
+		Token string `json:"token"`
+	}{}
+
+	json.NewDecoder(req.Body).Decode(&p)
+	if p.Token != token {
+		t.Errorf("The body should have attributes, but it didn't. Instead, the body was %s",
+			req.Body)
 	}
 }
 

--- a/token.go
+++ b/token.go
@@ -130,12 +130,13 @@ func match(r *http.Request, sess *sessions.Session, refresh bool) bool {
 			// Prevents throwing an error if nil
 			b := bytes.NewBuffer(make([]byte, 0))
 			body_reader := io.TeeReader(r.Body, b)
-			if body_reader == nil {
+			if r.Body == nil {
 				break
 			}
 			var t interface{}
 			decoder := json.NewDecoder(body_reader)
 			err := decoder.Decode(&t)
+
 			// If the response is JSON
 			if err == nil {
 				vals := t.(map[string]interface{})


### PR DESCRIPTION
This patch fixed the problem that a client couldn't read the http body
because it was already read